### PR TITLE
Add extendExpectation() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Just make sure your global vendor binaries directory is in your `$PATH`. See [th
 
 ## Assertions
 
-Corretto has built-in support for the following assertions:
+Corretto has built-in support for basic assertions:
 
 - `assertTrue()`
 - `assertFalse()`
 - `assertEquals()`
 - `assertNotEquals()`
 
-It also supports expect syntax:
+It also supports expect syntax, which is recommended:
 
 - `expect( $actual )->toBeTrue()`
 - `expect( $actual )->toBeFalse()`
@@ -57,9 +57,44 @@ It also supports expect syntax:
 - `expect( $actual )->toContain( $expected )`
 - `expect( $actual )->toNotContain( $expected )`
 
-Writing custom assertions is easy too. Anything that throws an `Exception` counts as a test failure!
+## Custom Assertions
+
+Writing custom assertions is easy. Any function that throws an `Exception` counts as a test failure!
 
 (You can also throw `\Corretto\AssertionFailure` which will provide slightly less noisy failures.)
+
+To add new methods to `expect()`, you can use the function `extendExpectation()` which is passed an Expectation class. An Expectation class is any class with methods that should respond to the expectation. The class should also have a constructor that accepts the actual value.
+
+Here's an example of adding `toContain()` to `expect()`:
+
+```php
+class ContainExpectation {
+	function __construct( $actual ) {
+		$this->actual = $actual;
+	}
+
+	public function toContain( $expected ) {
+		$actual = $this->actual;
+		if ( is_string( $actual ) && strpos( $actual, $expected ) === false ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new \Corretto\AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
+		}
+		if ( is_array( $actual ) && ! in_array( $expected, $actual ) ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new \Corretto\AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
+		}
+	}
+}
+```
+
+Here's an example of registering that expectation:
+
+```php
+use function \Corretto\extendExpectation;
+extendExpectation( '\Corretto\ContainExpectation' );
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -63,37 +63,28 @@ Writing custom assertions is easy. Any function that throws an `Exception` count
 
 (You can also throw `\Corretto\AssertionFailure` which will provide slightly less noisy failures.)
 
-To add new methods to `expect()`, you can use the function `extendExpectation()` which is passed an Expectation class. An Expectation class is any class with methods that should respond to the expectation. The class should also have a constructor that accepts the actual value.
+To add new methods to `expect()`, you'll need to create a class that extends `Corretto\Expectation`. Within the class, add methods that test the value of `$this->actual`, which is the value passed to `expect()`. Then pass the class to the function `Corretto\extendExpectation()`.
 
-Here's an example of adding `toContain()` to `expect()`:
+For example, to add the method `toBeFoo()`, you would write the following:
 
 ```php
-class ContainExpectation {
-	function __construct( $actual ) {
-		$this->actual = $actual;
-	}
-
-	public function toContain( $expected ) {
-		$actual = $this->actual;
-		if ( is_string( $actual ) && strpos( $actual, $expected ) === false ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new \Corretto\AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
-		}
-		if ( is_array( $actual ) && ! in_array( $expected, $actual ) ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new \Corretto\AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
+class FooExpectation extends Corretto\Expectation {
+	public function toBeFoo() {
+		if ( ! $this->actual === 'foo' ) {
+			throw new \Exception( 'not foo' );
 		}
 	}
 }
+Corretto\extendExpectation( 'FooExpectation' );
 ```
 
-Here's an example of registering that expectation:
+It is then possible to use this method in your tests, like this:
 
 ```php
-use function \Corretto\extendExpectation;
-extendExpectation( '\Corretto\ContainExpectation' );
+test( 'string is "foo"', function() {
+	$string = 'foo';
+	expect( $string )->toBeFoo();
+} );
 ```
 
 ## Tests

--- a/src/Corretto/BaseExpectation.php
+++ b/src/Corretto/BaseExpectation.php
@@ -1,0 +1,87 @@
+<?php
+namespace Corretto;
+
+class BaseExpectation extends Expectation {
+	private static $extensions = [];
+
+	public static function extendExpectation( $Extension ) {
+		self::$extensions[] = $Extension;
+	}
+
+	public function __call( $name, $arguments ) {
+		foreach( self::$extensions as $Extension ) {
+			$instance = new $Extension( $this->actual );
+			if ( method_exists( $instance, $name ) ) {
+				return call_user_func_array( [ $instance, $name ], $arguments );
+			}
+		}
+		throw new \Exception( "Call to undefined method Corretto\Expectation::$name()" );
+	}
+
+	public function toBeTrue() {
+		$expression = $this->actual;
+		if ( ! $expression ) {
+			throw new AssertionFailure( "Failed asserting that '" . var_export( $expression, true ) . "' is true" );
+		}
+	}
+
+	public function toBeFalse() {
+		$expression = $this->actual;
+		if ( $expression ) {
+			throw new AssertionFailure( "Failed asserting that '" . var_export( $expression, true ) . "' is false" );
+		}
+	}
+
+	public function toEqual( $expected ) {
+		$helper = new Helpers();
+		$actual = $helper->recursiveAssocSort( $this->actual );
+		$expected = $helper->recursiveAssocSort( $expected );
+		if ( $expected !== $actual ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			// print_r() gives a more readable version of objects
+			if ( is_object( $expected ) ) {
+				$expectedString = print_r( $expected, true );
+			}
+			if ( is_object( $actual ) ) {
+				$actualString = print_r( $actual, true );
+			}
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " is equal to " . $expectedString . "" );
+		}
+	}
+
+	public function toNotEqual( $expected ) {
+		$actual = $this->actual;
+		if ( $expected === $actual ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			// print_r() gives a more readable version of objects
+			if ( is_object( $expected ) ) {
+				$expectedString = print_r( $expected, true );
+			}
+			if ( is_object( $actual ) ) {
+				$actualString = print_r( $actual, true );
+			}
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " is not equal to " . $expectedString . "" );
+		}
+	}
+
+	public function toBeGreaterThan( $expected ) {
+		$actual = $this->actual;
+		if ( $actual <= $expected ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " is greater than " . $expectedString . "" );
+		}
+	}
+
+	public function toBeLessThan( $expected ) {
+		$actual = $this->actual;
+		if ( $actual >= $expected ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " is less than " . $expectedString . "" );
+		}
+	}
+}
+

--- a/src/Corretto/ContainExpectation.php
+++ b/src/Corretto/ContainExpectation.php
@@ -1,0 +1,36 @@
+<?php
+namespace Corretto;
+
+class ContainExpectation {
+	function __construct( $actual ) {
+		$this->actual = $actual;
+	}
+
+	public function toContain( $expected ) {
+		$actual = $this->actual;
+		if ( is_string( $actual ) && strpos( $actual, $expected ) === false ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
+		}
+		if ( is_array( $actual ) && ! in_array( $expected, $actual ) ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
+		}
+	}
+
+	public function toNotContain( $expected ) {
+		$actual = $this->actual;
+		if ( is_string( $actual ) && strpos( $actual, $expected ) !== false ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " does not contain " . $expectedString . "" );
+		}
+		if ( is_array( $actual ) && in_array( $expected, $actual ) ) {
+			$expectedString = var_export( $expected, true );
+			$actualString = var_export( $actual, true );
+			throw new AssertionFailure( "Failed asserting that " . $actualString . " does not contain " . $expectedString . "" );
+		}
+	}
+}

--- a/src/Corretto/ContainExpectation.php
+++ b/src/Corretto/ContainExpectation.php
@@ -1,11 +1,7 @@
 <?php
 namespace Corretto;
 
-class ContainExpectation {
-	function __construct( $actual ) {
-		$this->actual = $actual;
-	}
-
+class ContainExpectation extends Expectation {
 	public function toContain( $expected ) {
 		$actual = $this->actual;
 		if ( is_string( $actual ) && strpos( $actual, $expected ) === false ) {

--- a/src/Corretto/Expect.php
+++ b/src/Corretto/Expect.php
@@ -2,99 +2,11 @@
 namespace Corretto;
 
 function expect( $actual ) {
-	return new Expectation( $actual );
+	return new BaseExpectation( $actual );
 }
 
 function extendExpectation( $newExpectation ) {
-	Expectation::extendExpectation( $newExpectation );
-}
-
-class Expectation {
-	private static $extensions = [];
-
-	public static function extendExpectation( $Extension ) {
-		self::$extensions[] = $Extension;
-	}
-
-	function __construct( $actual ) {
-		$this->actual = $actual;
-	}
-
-	public function __call( $name, $arguments ) {
-		foreach( self::$extensions as $Extension ) {
-			$instance = new $Extension( $this->actual );
-			if ( method_exists( $instance, $name ) ) {
-				return call_user_func_array( [ $instance, $name ], $arguments );
-			}
-		}
-		throw new \Exception( "Call to undefined method Corretto\Expectation::$name()" );
-	}
-
-	public function toBeTrue() {
-		$expression = $this->actual;
-		if ( ! $expression ) {
-			throw new AssertionFailure( "Failed asserting that '" . var_export( $expression, true ) . "' is true" );
-		}
-	}
-
-	public function toBeFalse() {
-		$expression = $this->actual;
-		if ( $expression ) {
-			throw new AssertionFailure( "Failed asserting that '" . var_export( $expression, true ) . "' is false" );
-		}
-	}
-
-	public function toEqual( $expected ) {
-		$helper = new Helpers();
-		$actual = $helper->recursiveAssocSort( $this->actual );
-		$expected = $helper->recursiveAssocSort( $expected );
-		if ( $expected !== $actual ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			// print_r() gives a more readable version of objects
-			if ( is_object( $expected ) ) {
-				$expectedString = print_r( $expected, true );
-			}
-			if ( is_object( $actual ) ) {
-				$actualString = print_r( $actual, true );
-			}
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " is equal to " . $expectedString . "" );
-		}
-	}
-
-	public function toNotEqual( $expected ) {
-		$actual = $this->actual;
-		if ( $expected === $actual ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			// print_r() gives a more readable version of objects
-			if ( is_object( $expected ) ) {
-				$expectedString = print_r( $expected, true );
-			}
-			if ( is_object( $actual ) ) {
-				$actualString = print_r( $actual, true );
-			}
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " is not equal to " . $expectedString . "" );
-		}
-	}
-
-	public function toBeGreaterThan( $expected ) {
-		$actual = $this->actual;
-		if ( $actual <= $expected ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " is greater than " . $expectedString . "" );
-		}
-	}
-
-	public function toBeLessThan( $expected ) {
-		$actual = $this->actual;
-		if ( $actual >= $expected ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " is less than " . $expectedString . "" );
-		}
-	}
+	BaseExpectation::extendExpectation( $newExpectation );
 }
 
 extendExpectation( '\Corretto\ContainExpectation' );

--- a/src/Corretto/Expect.php
+++ b/src/Corretto/Expect.php
@@ -45,8 +45,9 @@ class Expectation {
 	}
 
 	public function toEqual( $expected ) {
-		$actual = $this->recursiveAssocSort( $this->actual );
-		$expected = $this->recursiveAssocSort( $expected );
+		$helper = new Helpers();
+		$actual = $helper->recursiveAssocSort( $this->actual );
+		$expected = $helper->recursiveAssocSort( $expected );
 		if ( $expected !== $actual ) {
 			$expectedString = var_export( $expected, true );
 			$actualString = var_export( $actual, true );
@@ -94,59 +95,6 @@ class Expectation {
 			throw new AssertionFailure( "Failed asserting that " . $actualString . " is less than " . $expectedString . "" );
 		}
 	}
-
-	private function recursiveAssocSort( $elements ) {
-		if ( ! is_array( $elements ) ) {
-			return $elements;
-		}
-		$elements = array_map( function( $el ) {
-			return $this->recursiveAssocSort( $el );
-		}, $elements );
-		if ( ! $this->hasStringKeys( $elements ) ) {
-			return $elements;
-		}
-		sort( $elements );
-		return $elements;
-	}
-
-	private function hasStringKeys( array $array ) {
-		return count( array_filter( array_keys( $array ), 'is_string' ) ) > 0;
-	}
-}
-
-class ContainExpectation {
-	function __construct( $actual ) {
-		$this->actual = $actual;
-	}
-
-	public function toContain( $expected ) {
-		$actual = $this->actual;
-		if ( is_string( $actual ) && strpos( $actual, $expected ) === false ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
-		}
-		if ( is_array( $actual ) && ! in_array( $expected, $actual ) ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " contains " . $expectedString . "" );
-		}
-	}
-
-	public function toNotContain( $expected ) {
-		$actual = $this->actual;
-		if ( is_string( $actual ) && strpos( $actual, $expected ) !== false ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " does not contain " . $expectedString . "" );
-		}
-		if ( is_array( $actual ) && in_array( $expected, $actual ) ) {
-			$expectedString = var_export( $expected, true );
-			$actualString = var_export( $actual, true );
-			throw new AssertionFailure( "Failed asserting that " . $actualString . " does not contain " . $expectedString . "" );
-		}
-	}
 }
 
 extendExpectation( '\Corretto\ContainExpectation' );
-

--- a/src/Corretto/Expect.php
+++ b/src/Corretto/Expect.php
@@ -5,9 +5,29 @@ function expect( $actual ) {
 	return new Expectation( $actual );
 }
 
+function extendExpectation( $newExpectation ) {
+	Expectation::extendExpectation( $newExpectation );
+}
+
 class Expectation {
+	private static $extensions = [];
+
+	public static function extendExpectation( $Extension ) {
+		self::$extensions[] = $Extension;
+	}
+
 	function __construct( $actual ) {
 		$this->actual = $actual;
+	}
+
+	public function __call( $name, $arguments ) {
+		foreach( self::$extensions as $Extension ) {
+			$instance = new $Extension( $this->actual );
+			if ( method_exists( $instance, $name ) ) {
+				return call_user_func_array( [ $instance, $name ], $arguments );
+			}
+		}
+		throw new \Exception( "Call to undefined method Corretto\Expectation::$name()" );
 	}
 
 	public function toBeTrue() {
@@ -22,24 +42,6 @@ class Expectation {
 		if ( $expression ) {
 			throw new AssertionFailure( "Failed asserting that '" . var_export( $expression, true ) . "' is false" );
 		}
-	}
-
-	private function recursiveAssocSort( $elements ) {
-		if ( ! is_array( $elements ) ) {
-			return $elements;
-		}
-		$elements = array_map( function( $el ) {
-			return $this->recursiveAssocSort( $el );
-		}, $elements );
-		if ( ! $this->hasStringKeys( $elements ) ) {
-			return $elements;
-		}
-		sort( $elements );
-		return $elements;
-	}
-
-	private function hasStringKeys( array $array ) {
-		return count( array_filter( array_keys( $array ), 'is_string' ) ) > 0;
 	}
 
 	public function toEqual( $expected ) {
@@ -93,6 +95,30 @@ class Expectation {
 		}
 	}
 
+	private function recursiveAssocSort( $elements ) {
+		if ( ! is_array( $elements ) ) {
+			return $elements;
+		}
+		$elements = array_map( function( $el ) {
+			return $this->recursiveAssocSort( $el );
+		}, $elements );
+		if ( ! $this->hasStringKeys( $elements ) ) {
+			return $elements;
+		}
+		sort( $elements );
+		return $elements;
+	}
+
+	private function hasStringKeys( array $array ) {
+		return count( array_filter( array_keys( $array ), 'is_string' ) ) > 0;
+	}
+}
+
+class ContainExpectation {
+	function __construct( $actual ) {
+		$this->actual = $actual;
+	}
+
 	public function toContain( $expected ) {
 		$actual = $this->actual;
 		if ( is_string( $actual ) && strpos( $actual, $expected ) === false ) {
@@ -121,3 +147,6 @@ class Expectation {
 		}
 	}
 }
+
+extendExpectation( '\Corretto\ContainExpectation' );
+

--- a/src/Corretto/Expectation.php
+++ b/src/Corretto/Expectation.php
@@ -1,0 +1,8 @@
+<?php
+namespace Corretto;
+
+class Expectation {
+	function __construct( $actual ) {
+		$this->actual = $actual;
+	}
+}

--- a/src/Corretto/Helpers.php
+++ b/src/Corretto/Helpers.php
@@ -1,0 +1,22 @@
+<?php
+namespace Corretto;
+
+class Helpers {
+	public function recursiveAssocSort( $elements ) {
+		if ( ! is_array( $elements ) ) {
+			return $elements;
+		}
+		$elements = array_map( function( $el ) {
+			return $this->recursiveAssocSort( $el );
+		}, $elements );
+		if ( ! $this->hasStringKeys( $elements ) ) {
+			return $elements;
+		}
+		sort( $elements );
+		return $elements;
+	}
+
+	public function hasStringKeys( array $array ) {
+		return count( array_filter( array_keys( $array ), 'is_string' ) ) > 0;
+	}
+}

--- a/tests/Expect.php
+++ b/tests/Expect.php
@@ -3,6 +3,35 @@
 use function \Corretto\describe;
 use function \Corretto\it;
 use function \Corretto\expect;
+use function \Corretto\extendExpectation;
+
+class FooExpectation {
+	public function __construct( $actual ) {
+		$this->actual = $actual;
+	}
+
+	public function toBeFoo() {
+		if ( ! $this->actual === 'foo' ) {
+			throw new \Exception( 'not foo' );
+		}
+	}
+}
+
+describe( 'extendExpectation()', function() {
+	it( 'when not used, does not add a method to expect()', function() {
+		try {
+			expect( 'foo' )->toBeFoo();
+		} catch ( Exception $e ) {
+			return;
+		}
+		throw new Exception( 'calling an undefined method on expect() did not fail' );
+	} );
+
+	it( 'adds methods on the passed class to the object returned by expect()', function() {
+		extendExpectation( 'FooExpectation' );
+		expect( 'foo' )->toBeFoo();
+	} );
+} );
 
 describe( 'expect()', function() {
 	describe( 'toBeTrue()', function() {

--- a/tests/Expect.php
+++ b/tests/Expect.php
@@ -5,11 +5,7 @@ use function \Corretto\it;
 use function \Corretto\expect;
 use function \Corretto\extendExpectation;
 
-class FooExpectation {
-	public function __construct( $actual ) {
-		$this->actual = $actual;
-	}
-
+class FooExpectation extends Corretto\Expectation {
 	public function toBeFoo() {
 		if ( ! $this->actual === 'foo' ) {
 			throw new \Exception( 'not foo' );


### PR DESCRIPTION
Adds the `extendExpectation()` method, which allows adding methods to `expect()`.

We do not use inheritance because we need to be able to extend the expectation multiple times. This method uses a first-registered technique to add methods only if they do not already exist.

To add new methods to `expect()`, you'll need to create a class that extends `Corretto\Expectation`. Within the class, add methods that test the value of `$this->actual`, which is the value passed to `expect()`. Then pass the class to the function `Corretto\extendExpectation()`.

For example, to add the method `toBeFoo()`, you would write the following:

```php
class FooExpectation extends Corretto\Expectation {
	public function toBeFoo() {
		if ( ! $this->actual === 'foo' ) {
			throw new \Exception( 'not foo' );
		}
	}
}
Corretto\extendExpectation( 'FooExpectation' );
```

It is then possible to use this method in your tests, like this:

```php
test( 'string is "foo"', function() {
  $string = 'foo';
  expect( $string )->toBeFoo();
} );
```

Fixes #5 